### PR TITLE
Nette\DI: apiKey should not have blank default

### DIFF
--- a/DotBlue/Mandrill/NetteBridge/DI/MandrillExtension.php
+++ b/DotBlue/Mandrill/NetteBridge/DI/MandrillExtension.php
@@ -17,7 +17,6 @@ class MandrillExtension extends \Nette\DI\CompilerExtension
 	 * @var array
 	 */
 	public $defaults = [
-		'apiKey' => '',
 		'replaceNetteMailer' => TRUE,
 	];
 


### PR DESCRIPTION
This will solve `api_key` vs. `apiKey` problem :). App should scream when this is not filled in.
